### PR TITLE
Bug fixes related to JSON-RPC server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ dependencies = [
  "etcommon-rlp 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "etcommon-trie 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 7.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-http-server 7.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-http-server-plus 7.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-macros-plus 7.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -308,7 +308,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpc-http-server"
+name = "jsonrpc-http-server-plus"
 version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -901,7 +901,7 @@ dependencies = [
 "checksum iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29d062ee61fccdf25be172e70f34c9f6efc597e1fb8f6526e8437b2046ab26be"
 "checksum itoa 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f74cf6ca1bdbc28496a2b9798ab7fccc2ca5a42cace95bb2b219577216a5fb90"
 "checksum jsonrpc-core 7.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "903e5eee845f3d83c1436d12848d97b1247cf850ff06a8e1db2f1ce3543af2cf"
-"checksum jsonrpc-http-server 7.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "14fe02e231e83734886954cd8797c7b501fbc270ed780ca3c0635bab862557c3"
+"checksum jsonrpc-http-server-plus 7.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1347be541a9c55ffc679a75e0345dda6e4f33c95f99d7d475391aae21f349670"
 "checksum jsonrpc-macros-plus 7.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5425d0bcfb7cf934e650cdb0e99562973f3030d5bdfae72deb79aa562618eeba"
 "checksum jsonrpc-pubsub 7.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "89fface9179d4b7aa54b56cb774d3d95c1b853adc05d36eb1b2d1195e5ec3cdb"
 "checksum jsonrpc-server-utils 7.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1ea39cce7a00b830f1d501c78f86356209d23709ebb11434b10cb5f0391ba7da"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ etcommon-bloom = "0.2"
 etcommon-rlp = "0.2"
 etcommon-hexutil = "0.2"
 lazy_static = "0.2"
-jsonrpc-core = "7.1"
-jsonrpc-http-server = "7.1"
-jsonrpc-macros-plus = "7.1"
+jsonrpc-core = { version = "7.1" }
+jsonrpc-http-server-plus = { version = "7.1" }
+jsonrpc-macros-plus = { version = "7.1" }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,5 +31,5 @@ fn main() {
         miner::mine_loop();
     });
 
-    rpc::rpc_loop(&"127.0.0.1:9545".parse().unwrap());
+    rpc::rpc_loop(&"127.0.0.1:8545".parse().unwrap());
 }

--- a/src/miner/mod.rs
+++ b/src/miner/mod.rs
@@ -15,6 +15,7 @@ use sputnikvm::vm::errors::RequireError;
 use rand::os::OsRng;
 use sha3::{Digest, Keccak256};
 use blockchain::chain::HeaderHash;
+use hexutil::*;
 
 mod state;
 
@@ -93,6 +94,9 @@ pub fn mine_loop() {
     let secret_key = SecretKey::new(&SECP256K1, &mut rng);
     let address = Address::from_secret_key(&secret_key).unwrap();
     println!("address: {:?}", address);
+    println!("private key: {}", to_hex(&secret_key[..]));
+
+    state::append_account(secret_key);
 
     {
         let mut stateful = state::stateful();
@@ -177,8 +181,6 @@ pub fn mine_loop() {
                                   beneficiary, Gas::from_str("0x10000000000000000000000").unwrap(),
                                   stateful.root());
             state::append_block(next_block);
-
-            println!("mined a new block: {:?}", state::current_block());
         }
 
         thread::sleep(Duration::from_millis(10000));

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -98,6 +98,7 @@ pub struct RPCTransaction {
     pub gas: Option<String>,
     pub gas_price: Option<String>,
     pub value: Option<String>,
+    #[serde(default)]
     pub data: String,
     pub nonce: Option<String>,
 


### PR DESCRIPTION
Fix several bugs related to JSON-RPC server and tested against MyEtherWallet (note that you'll need to run a localhost version to get it working due to HTTPS requirements).

If you would like to help further test this, in startup `cargo run` it will display the testing account address and its private key. Use them for sending transactions.