### PR TITLE
Fix `truffle migrate` and several RPC calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sputnikvm 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sputnikvm-stateful 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sputnikvm-stateful 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "sputnikvm-stateful"
-version = "0.6.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "etcommon-block 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1031,7 +1031,7 @@ dependencies = [
 "checksum smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c8cbcd6df1e117c2210e13ab5109635ad68a929fcbb8964dc965b76cb5ee013"
 "checksum smallvec 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8fcd03faf178110ab0334d74ca9631d77f94c8c11cc77fcb59538abf0025695d"
 "checksum sputnikvm 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7893df34177b0188ec75ff4f040d1ff521241702ac30d2fd24a144433af65c26"
-"checksum sputnikvm-stateful 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8fcc20b487a5b4dc1dea3fb3d6ab39a91fd7360d04797efe6757f6e210d8577"
+"checksum sputnikvm-stateful 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0ecec1a49b6cb884f2e50be78211ee27978ed8ea58f6a0abb50bc65c826cd4f3"
 "checksum stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15132e0e364248108c5e2c02e3ab539be8d6f5d52a01ca9bbf27ed657316f02b"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,7 @@ version = "0.1.0"
 dependencies = [
  "blockchain 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "etcommon-bigint 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "etcommon-block 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "etcommon-bloom 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -14,6 +15,7 @@ dependencies = [
  "jsonrpc-http-server-plus 7.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-macros-plus 7.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1-plus 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -161,6 +163,15 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heapsize 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -953,6 +964,7 @@ dependencies = [
 "checksum digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5b29bf156f3f4b3c4f610a25ff69370616ae6e0657d416de22645483e72af0a"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum elastic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "258ff6a9a94f648d0379dbd79110e057edbb53eb85cc237e33eadf8e5a30df85"
+"checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
 "checksum etcommon-bigint 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "55d7e2cc47e6d69bef8447ba4a89b2817276a6d5b1859eeb93bc2d03879edb6f"
 "checksum etcommon-block 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8199bb1c6bf1a3628fabe097bca5693a66e0c16d0389fc9e026d180ab20f3e74"
 "checksum etcommon-bloom 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "43844778eb139dc011f9e11abd509befd4075d42e7f6875a64b7a522511278af"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,5 @@ jsonrpc-macros-plus = { version = "7.1" }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
+log = "0.3"
+env_logger = "0.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,9 @@ extern crate serde_json;
 extern crate serde_derive;
 #[macro_use]
 extern crate clap;
+#[macro_use]
+extern crate log;
+extern crate env_logger;
 
 mod error;
 mod miner;
@@ -36,6 +39,7 @@ use std::thread;
 use std::str::FromStr;
 
 fn main() {
+    env_logger::init();
     let mut rng = OsRng::new().unwrap();
 
     let matches = clap_app!(

--- a/src/miner/mod.rs
+++ b/src/miner/mod.rs
@@ -22,8 +22,8 @@ mod state;
 pub use self::state::{append_pending_transaction,
                       block_height, get_block_by_hash, get_block_by_number, current_block,
                       get_transaction_by_hash, stateful, accounts, append_account,
-                      get_hash_raw, get_total_header_by_hash, get_total_header_by_number,
-                      get_transaction_block_hash_by_hash, get_receipt_by_hash,
+                      get_total_header_by_hash, get_total_header_by_number,
+                      get_transaction_block_hash_by_hash, get_receipt_by_transaction_hash,
                       all_pending_transaction_hashes, get_last_256_block_hashes};
 
 fn next<'a>(
@@ -48,8 +48,7 @@ fn next<'a>(
         transactions_trie.insert(rlp::encode(&i).to_vec(), transaction_rlp.clone());
         receipts_trie.insert(rlp::encode(&i).to_vec(), receipt_rlp.clone());
 
-        state::insert_hash_raw(transaction_hash, transaction_rlp);
-        state::insert_hash_raw(receipt_hash, receipt_rlp);
+        state::insert_receipt(transaction_hash, receipts[i].clone());
 
         logs_bloom = logs_bloom | receipts[i].logs_bloom.clone();
         gas_used = gas_used + receipts[i].used_gas.clone();
@@ -98,8 +97,6 @@ pub fn mine_loop(secret_key: SecretKey, balance: U256) {
 
     {
         let mut stateful = state::stateful();
-
-        state::insert_hash_raw(H256::from(Keccak256::digest(&[]).as_slice()), Vec::new());
 
         let genesis = Block {
             header: Header {

--- a/src/miner/state.rs
+++ b/src/miner/state.rs
@@ -19,7 +19,9 @@ lazy_static! {
     static ref BLOCK_HASHES: Mutex<Vec<H256>> = Mutex::new(Vec::new());
     static ref TRANSACTION_BLOCK_HASHES: Mutex<HashMap<H256, H256>> = Mutex::new(HashMap::new());
     static ref TOTAL_HEADERS: Mutex<HashMap<H256, TotalHeader>> = Mutex::new(HashMap::new());
-    static ref HASH_DATABASE: Mutex<HashMap<H256, Vec<u8>>> = Mutex::new(HashMap::new());
+    static ref TRANSACTION_DATABASE: Mutex<HashMap<H256, Transaction>> = Mutex::new(HashMap::new());
+    static ref BLOCK_DATABASE: Mutex<HashMap<H256, Block>> = Mutex::new(HashMap::new());
+    static ref RECEIPT_DATABASE: Mutex<HashMap<H256, Receipt>> = Mutex::new(HashMap::new());
     static ref ACCOUNTS: Mutex<Vec<SecretKey>> = Mutex::new(Vec::new());
     static ref STATEFUL: Mutex<MemoryStateful> = Mutex::new(MemoryStateful::default());
 }
@@ -27,8 +29,8 @@ lazy_static! {
 pub fn append_pending_transaction(transaction: Transaction) -> H256 {
     let value = rlp::encode(&transaction).to_vec();
     let hash = H256::from(Keccak256::digest(&value).as_slice());
-    insert_hash_raw(hash, value);
 
+    TRANSACTION_DATABASE.lock().unwrap().insert(hash, transaction);
     PENDING_TRANSACTION_HASHES.lock().unwrap().push(hash);
     ALL_PENDING_TRANSACTION_HASHES.lock().unwrap().push(hash);
 
@@ -44,8 +46,9 @@ pub fn clear_pending_transactions() -> Vec<Transaction> {
     };
 
     let mut transactions = Vec::new();
+    let database = TRANSACTION_DATABASE.lock().unwrap();
     for hash in transaction_hashes {
-        transactions.push(rlp::decode(&get_hash_raw(hash).unwrap()))
+        transactions.push(database.get(&hash).unwrap().clone());
     }
     transactions
 }
@@ -54,23 +57,16 @@ pub fn all_pending_transaction_hashes() -> Vec<H256> {
     ALL_PENDING_TRANSACTION_HASHES.lock().unwrap().clone()
 }
 
-pub fn insert_hash_raw(key: H256, value: Vec<u8>) {
-    HASH_DATABASE.lock().unwrap().insert(key, value);
-}
-
-pub fn get_hash_raw(key: H256) -> Result<Vec<u8>, Error> {
-    HASH_DATABASE.lock().unwrap().get(&key).map(|v| v.clone()).ok_or(Error::NotFound)
-}
-
 pub fn append_block(block: Block) -> H256 {
     let mut block_transaction_hashes = TRANSACTION_BLOCK_HASHES.lock().unwrap();
     let mut block_hashes = BLOCK_HASHES.lock().unwrap();
     let mut total_headers = TOTAL_HEADERS.lock().unwrap();
     let mut current_block = CURRENT_BLOCK.lock().unwrap();
+    let mut block_database = BLOCK_DATABASE.lock().unwrap();
 
     let value = rlp::encode(&block).to_vec();
     let hash = block.header.header_hash();
-    insert_hash_raw(hash, value);
+    block_database.insert(hash, block.clone());
 
     for transaction in &block.transactions {
         let transaction_hash = H256::from(Keccak256::digest(&rlp::encode(transaction).to_vec()).as_slice());
@@ -91,6 +87,10 @@ pub fn append_block(block: Block) -> H256 {
     hash
 }
 
+pub fn insert_receipt(transaction_hash: H256, receipt: Receipt) {
+    RECEIPT_DATABASE.lock().unwrap().insert(transaction_hash, receipt);
+}
+
 pub fn block_height() -> usize {
     BLOCK_HASHES.lock().unwrap().len() - 1
 }
@@ -100,22 +100,19 @@ pub fn get_transaction_block_hash_by_hash(key: H256) -> Result<H256, Error> {
 }
 
 pub fn get_block_by_hash(key: H256) -> Result<Block, Error> {
-    let v: Vec<u8> = get_hash_raw(key)?;
-    Ok(rlp::decode(&v))
+    BLOCK_DATABASE.lock().unwrap().get(&key).map(|v| v.clone()).ok_or(Error::NotFound)
 }
 
 pub fn get_transaction_by_hash(key: H256) -> Result<Transaction, Error> {
-    let v: Vec<u8> = get_hash_raw(key)?;
-    Ok(rlp::decode(&v))
+    TRANSACTION_DATABASE.lock().unwrap().get(&key).map(|v| v.clone()).ok_or(Error::NotFound)
 }
 
-pub fn get_receipt_by_hash(key: H256) -> Result<Receipt, Error> {
-    let v: Vec<u8> = get_hash_raw(key)?;
-    Ok(rlp::decode(&v))
+pub fn get_receipt_by_transaction_hash(key: H256) -> Result<Receipt, Error> {
+    RECEIPT_DATABASE.lock().unwrap().get(&key).map(|v| v.clone()).ok_or(Error::NotFound)
 }
 
 pub fn get_block_by_number(index: usize) -> Block {
-    rlp::decode(&get_hash_raw(BLOCK_HASHES.lock().unwrap()[index]).unwrap())
+    get_block_by_hash(BLOCK_HASHES.lock().unwrap()[index]).unwrap()
 }
 
 pub fn get_total_header_by_hash(key: H256) -> Result<TotalHeader, Error> {

--- a/src/miner/state.rs
+++ b/src/miner/state.rs
@@ -5,6 +5,7 @@ use block::{Receipt, Block, TotalHeader, UnsignedTransaction, Transaction, Trans
 use trie::{MemoryDatabase, MemoryDatabaseGuard, Trie};
 use bigint::{H256, M256, U256, H64, B256, Gas, Address};
 use sha3::{Digest, Keccak256};
+use blockchain::chain::HeaderHash;
 use secp256k1::key::SecretKey;
 use sputnikvm_stateful::{MemoryStateful};
 
@@ -68,7 +69,7 @@ pub fn append_block(block: Block) -> H256 {
     let mut current_block = CURRENT_BLOCK.lock().unwrap();
 
     let value = rlp::encode(&block).to_vec();
-    let hash = H256::from(Keccak256::digest(&value).as_slice());
+    let hash = block.header.header_hash();
     insert_hash_raw(hash, value);
 
     for transaction in &block.transactions {

--- a/src/rpc/filter.rs
+++ b/src/rpc/filter.rs
@@ -65,7 +65,7 @@ pub fn get_logs(filter: LogFilter) -> Result<Vec<RPCLog>, Error> {
         let block = miner::get_block_by_number(current_block_number);
         for transaction in &block.transactions {
             let transaction_hash = H256::from(Keccak256::digest(&rlp::encode(transaction).to_vec()).as_slice());
-            let receipt = miner::get_receipt_by_hash(transaction_hash)?;
+            let receipt = miner::get_receipt_by_transaction_hash(transaction_hash)?;
             for i in 0..receipt.logs.len() {
                 let log = &receipt.logs[i];
                 if check_log(log, 0, &filter.topics[0]) &&

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -175,7 +175,7 @@ build_rpc_trait! {
         #[rpc(name = "eth_getTransactionByBlockNumberAndIndex")]
         fn transaction_by_block_number_and_index(&self, String, String) -> Result<RPCTransaction, Error>;
         #[rpc(name = "eth_getTransactionReceipt")]
-        fn transaction_receipt(&self, String) -> Result<RPCReceipt, Error>;
+        fn transaction_receipt(&self, String) -> Result<Option<RPCReceipt>, Error>;
         #[rpc(name = "eth_getUncleByBlockHashAndIndex")]
         fn uncle_by_block_hash_and_index(&self, String, String) -> Result<RPCBlock, Error>;
         #[rpc(name = "eth_getUncleByBlockNumberAndIndex")]


### PR DESCRIPTION
Fix #12 reported by @gagarin55 and makes the following sequence in truffle work:

```
truffle init
truffle compile
truffle migrate
```