### PR TITLE
Unify `.` in the end of help messages and update readme about it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "sputnikvm-dev"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "blockchain 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/README.md
+++ b/README.md
@@ -17,11 +17,10 @@ FLAGS:
     -V, --version    Prints version information
 
 OPTIONS:
-    -b, --balance <BALANCE>        Balance in Wei for the account to be generated, default is
-                                   0x10000000000000000000000000000.
-    -l, --listen <LISTEN>          Listen address and port for the RPC, e.g. 127.0.0.1:8545
-    -k, --private <PRIVATE_KEY>    Private key for the account to be generated, if not
-                                   provided, a random private key will be generated.
+    -a, --accounts <ACCOUNTS>      Additional accounts to be generated, default to 9.
+    -b, --balance <BALANCE>        Balance in Wei for the account to be generated, default is 0x10000000000000000000000000000.
+    -l, --listen <LISTEN>          Listen address and port for the RPC, e.g. 127.0.0.1:8545.
+    -k, --private <PRIVATE_KEY>    Private key for the account to be generated, if not provided, a random private key will be generated.
 ```
 
 After started, `svmdev` will print out the address and private key with balance for testing. It will then generate new blocks every ten seconds, and inclue all pending transactions that yet to be confirmed. You can then use the RPC endpoints below to test your blockchain application.

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,8 +50,8 @@ fn main() {
             (about: "SputnikVM Development Environment, a replacement for ethereumjs-testrpc.")
             (@arg PRIVATE_KEY: -p --private-key +takes_value "Private key for the account to be generated, if not provided, a random private key will be generated.")
             (@arg BALANCE: -b --balance +takes_value "Balance in Wei for the account to be generated, default is 0x10000000000000000000000000000.")
-            (@arg LISTEN: -l --listen +takes_value "Listen address and port for the RPC, e.g. 127.0.0.1:8545")
-            (@arg ACCOUNTS: -a --accounts +takes_value "Additional accounts to be generated, default to 9")
+            (@arg LISTEN: -l --listen +takes_value "Listen address and port for the RPC, e.g. 127.0.0.1:8545.")
+            (@arg ACCOUNTS: -a --accounts +takes_value "Additional accounts to be generated, default to 9.")
     ).get_matches();
 
     let secret_key = match matches.value_of("PRIVATE_KEY") {


### PR DESCRIPTION
Add missing dots.