### PR TITLE
Use MinerState and remove global static

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "sputnikvm-dev"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "blockchain 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/README.md
+++ b/README.md
@@ -71,3 +71,13 @@ Below is a list of all the supported RPC endpoints by `sputnikvm-dev`.
 * [eth_getFilterChanges](#eth_getfilterchanges)
 * [eth_getFilterLogs](#eth_getfilterlogs)
 * [eth_getLogs](#eth_getlogs)
+
+## Planned Debug Endpoints
+
+* debug_dumpBlock
+* debug_getBlockRlp
+* debug_traceBlock
+* debug_traceBlockByNumber
+* debug_traceBlockByHash
+* debug_traceBlockFromFile
+* debug_traceTransaction

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ mod error;
 mod miner;
 mod rpc;
 
+use miner::MinerState;
 use rand::os::OsRng;
 use secp256k1::key::{PublicKey, SecretKey};
 use secp256k1::SECP256K1;
@@ -37,7 +38,9 @@ use bigint::U256;
 use hexutil::*;
 use std::thread;
 use std::str::FromStr;
+use std::sync::{Arc, Mutex};
 use std::sync::mpsc::{channel, Sender, Receiver};
+use sputnikvm::vm::EIP160_PATCH;
 
 fn main() {
     env_logger::init();
@@ -81,14 +84,14 @@ fn main() {
 
     let (sender, receiver) = channel::<bool>();
 
-    let patch = &'static EIP160_PATCH;
+    let patch = &EIP160_PATCH;
     let state = miner::make_state(genesis, patch);
 
     let miner_arc = Arc::new(Mutex::new(state));
     let rpc_arc = miner_arc.clone();
 
     thread::spawn(move || {
-        miner::mine_loop(miner_arc, genesis, receiver);
+        miner::mine_loop(miner_arc, receiver, patch);
     });
 
     rpc::rpc_loop(rpc_arc,

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,10 +81,17 @@ fn main() {
 
     let (sender, receiver) = channel::<bool>();
 
+    let patch = &'static EIP160_PATCH;
+    let state = miner::make_state(genesis, patch);
+
+    let miner_arc = Arc::new(Mutex::new(state));
+    let rpc_arc = miner_arc.clone();
+
     thread::spawn(move || {
-        miner::mine_loop(genesis, receiver);
+        miner::mine_loop(miner_arc, genesis, receiver);
     });
 
-    rpc::rpc_loop(&matches.value_of("LISTEN").unwrap_or("127.0.0.1:8545").parse().unwrap(),
+    rpc::rpc_loop(rpc_arc,
+                  &matches.value_of("LISTEN").unwrap_or("127.0.0.1:8545").parse().unwrap(),
                   sender);
 }

--- a/src/miner/state.rs
+++ b/src/miner/state.rs
@@ -37,11 +37,11 @@ impl MinerState {
 
         let value = rlp::encode(&genesis).to_vec();
         let hash = genesis.header.header_hash();
-        block_database.insert(hash, block.clone());
+        block_database.insert(hash, genesis.clone());
 
         assert!(genesis.transactions.len() == 0);
 
-        total_headers.insert(hash, TotalHeader::from_genesis(genesis.header.clone()));
+        total_header_database.insert(hash, TotalHeader::from_genesis(genesis.header.clone()));
         block_hashes.push(hash);
 
         let current_block = hash;
@@ -52,7 +52,7 @@ impl MinerState {
 
             all_pending_transaction_hashes: Vec::new(),
             pending_transaction_hashes: Vec::new(),
-            transaction_Database: HashMap::new(),
+            transaction_database: HashMap::new(),
             receipt_database: HashMap::new(),
 
             accounts: Vec::new(),
@@ -72,8 +72,8 @@ impl MinerState {
 
     pub fn clear_pending_transactions(&mut self) -> Vec<Transaction> {
         let transaction_hashes = {
-            let ret_hashes = self.pending_transactions.clone();
-            self.pending_transactions.clear();
+            let ret_hashes = self.pending_transaction_hashes.clone();
+            self.pending_transaction_hashes.clear();
             ret_hashes
         };
 
@@ -95,11 +95,11 @@ impl MinerState {
 
         for transaction in &block.transactions {
             let transaction_hash = H256::from(Keccak256::digest(&rlp::encode(transaction).to_vec()).as_slice());
-            self.block_transaction_hashes.insert(transaction_hash, hash);
+            self.transaction_block_hashes.insert(transaction_hash, hash);
         }
 
         assert!(self.block_hashes.len() > 0);
-        let parent_hash = self.block_hashes[block_hashes.len() - 1];
+        let parent_hash = self.block_hashes[self.block_hashes.len() - 1];
         let parent = self.total_header_database.get(&parent_hash).unwrap().clone();
         self.total_header_database.insert(hash, TotalHeader::from_parent(block.header.clone(), &parent));
 

--- a/src/miner/state.rs
+++ b/src/miner/state.rs
@@ -12,143 +12,170 @@ use sputnikvm_stateful::{MemoryStateful};
 use std::sync::{Mutex, MutexGuard};
 use std::collections::HashMap;
 
-lazy_static! {
-    static ref ALL_PENDING_TRANSACTION_HASHES: Mutex<Vec<H256>> = Mutex::new(Vec::new());
-    static ref PENDING_TRANSACTION_HASHES: Mutex<Vec<H256>> = Mutex::new(Vec::new());
-    static ref CURRENT_BLOCK: Mutex<H256> = Mutex::new(H256::default());
-    static ref BLOCK_HASHES: Mutex<Vec<H256>> = Mutex::new(Vec::new());
-    static ref TRANSACTION_BLOCK_HASHES: Mutex<HashMap<H256, H256>> = Mutex::new(HashMap::new());
-    static ref TOTAL_HEADERS: Mutex<HashMap<H256, TotalHeader>> = Mutex::new(HashMap::new());
-    static ref TRANSACTION_DATABASE: Mutex<HashMap<H256, Transaction>> = Mutex::new(HashMap::new());
-    static ref BLOCK_DATABASE: Mutex<HashMap<H256, Block>> = Mutex::new(HashMap::new());
-    static ref RECEIPT_DATABASE: Mutex<HashMap<H256, Receipt>> = Mutex::new(HashMap::new());
-    static ref ACCOUNTS: Mutex<Vec<SecretKey>> = Mutex::new(Vec::new());
-    static ref STATEFUL: Mutex<MemoryStateful> = Mutex::new(MemoryStateful::default());
+pub struct MinerState {
+    all_pending_transaction_hashes: Vec<H256>,
+    pending_transaction_hashes: Vec<H256>,
+    current_block: H256,
+    block_hashes: Vec<H256>,
+    transaction_block_hashes: HashMap<H256, H256>,
+
+    total_header_database: HashMap<H256, TotalHeader>,
+    transaction_database: HashMap<H256, Transaction>,
+    block_database: HashMap<H256, Block>,
+    receipt_database: HashMap<H256, Receipt>,
+
+    accounts: Vec<SecretKey>,
+    stateful: MemoryStateful,
 }
 
-pub fn append_pending_transaction(transaction: Transaction) -> H256 {
-    let value = rlp::encode(&transaction).to_vec();
-    let hash = H256::from(Keccak256::digest(&value).as_slice());
+impl MinerState {
+    pub fn new(genesis: Block, stateful: MemoryStateful) -> Self {
+        let mut block_database = HashMap::new();
+        let mut transaction_block_hashes = HashMap::new();
+        let mut total_header_database = HashMap::new();
+        let mut block_hashes = Vec::new();
 
-    TRANSACTION_DATABASE.lock().unwrap().insert(hash, transaction);
-    PENDING_TRANSACTION_HASHES.lock().unwrap().push(hash);
-    ALL_PENDING_TRANSACTION_HASHES.lock().unwrap().push(hash);
+        let value = rlp::encode(&genesis).to_vec();
+        let hash = genesis.header.header_hash();
+        block_database.insert(hash, block.clone());
 
-    hash
-}
+        assert!(genesis.transactions.len() == 0);
 
-pub fn clear_pending_transactions() -> Vec<Transaction> {
-    let transaction_hashes = {
-        let mut pending_transactions = PENDING_TRANSACTION_HASHES.lock().unwrap();
-        let ret_hashes = pending_transactions.clone();
-        pending_transactions.clear();
-        ret_hashes
-    };
+        total_headers.insert(hash, TotalHeader::from_genesis(genesis.header.clone()));
+        block_hashes.push(hash);
 
-    let mut transactions = Vec::new();
-    let database = TRANSACTION_DATABASE.lock().unwrap();
-    for hash in transaction_hashes {
-        transactions.push(database.get(&hash).unwrap().clone());
-    }
-    transactions
-}
+        let current_block = hash;
 
-pub fn all_pending_transaction_hashes() -> Vec<H256> {
-    ALL_PENDING_TRANSACTION_HASHES.lock().unwrap().clone()
-}
+        Self {
+            block_database, transaction_block_hashes, total_header_database,
+            block_hashes, current_block, stateful,
 
-pub fn append_block(block: Block) -> H256 {
-    let mut block_transaction_hashes = TRANSACTION_BLOCK_HASHES.lock().unwrap();
-    let mut block_hashes = BLOCK_HASHES.lock().unwrap();
-    let mut total_headers = TOTAL_HEADERS.lock().unwrap();
-    let mut current_block = CURRENT_BLOCK.lock().unwrap();
-    let mut block_database = BLOCK_DATABASE.lock().unwrap();
+            all_pending_transaction_hashes: Vec::new(),
+            pending_transaction_hashes: Vec::new(),
+            transaction_Database: HashMap::new(),
+            receipt_database: HashMap::new(),
 
-    let value = rlp::encode(&block).to_vec();
-    let hash = block.header.header_hash();
-    block_database.insert(hash, block.clone());
-
-    for transaction in &block.transactions {
-        let transaction_hash = H256::from(Keccak256::digest(&rlp::encode(transaction).to_vec()).as_slice());
-        block_transaction_hashes.insert(transaction_hash, hash);
-    }
-
-    if block_hashes.len() == 0 {
-        total_headers.insert(hash, TotalHeader::from_genesis(block.header.clone()));
-    } else {
-        let parent_hash = block_hashes[block_hashes.len() - 1];
-        let parent = total_headers.get(&parent_hash).unwrap().clone();
-        total_headers.insert(hash, TotalHeader::from_parent(block.header.clone(), &parent));
-    }
-
-    block_hashes.push(hash);
-    *current_block = hash;
-
-    hash
-}
-
-pub fn insert_receipt(transaction_hash: H256, receipt: Receipt) {
-    RECEIPT_DATABASE.lock().unwrap().insert(transaction_hash, receipt);
-}
-
-pub fn block_height() -> usize {
-    BLOCK_HASHES.lock().unwrap().len() - 1
-}
-
-pub fn get_transaction_block_hash_by_hash(key: H256) -> Result<H256, Error> {
-    TRANSACTION_BLOCK_HASHES.lock().unwrap().get(&key).map(|v| v.clone()).ok_or(Error::NotFound)
-}
-
-pub fn get_block_by_hash(key: H256) -> Result<Block, Error> {
-    BLOCK_DATABASE.lock().unwrap().get(&key).map(|v| v.clone()).ok_or(Error::NotFound)
-}
-
-pub fn get_transaction_by_hash(key: H256) -> Result<Transaction, Error> {
-    TRANSACTION_DATABASE.lock().unwrap().get(&key).map(|v| v.clone()).ok_or(Error::NotFound)
-}
-
-pub fn get_receipt_by_transaction_hash(key: H256) -> Result<Receipt, Error> {
-    RECEIPT_DATABASE.lock().unwrap().get(&key).map(|v| v.clone()).ok_or(Error::NotFound)
-}
-
-pub fn get_block_by_number(index: usize) -> Block {
-    get_block_by_hash(BLOCK_HASHES.lock().unwrap()[index]).unwrap()
-}
-
-pub fn get_total_header_by_hash(key: H256) -> Result<TotalHeader, Error> {
-    TOTAL_HEADERS.lock().unwrap().get(&key).map(|v| v.clone()).ok_or(Error::NotFound)
-}
-
-pub fn get_total_header_by_number(index: usize) -> TotalHeader {
-    TOTAL_HEADERS.lock().unwrap().get(&BLOCK_HASHES.lock().unwrap()[index]).map(|v| v.clone()).unwrap()
-}
-
-pub fn get_last_256_block_hashes() -> Vec<H256> {
-    let mut hashes = BLOCK_HASHES.lock().unwrap().clone();
-    let mut ret = Vec::new();
-
-    for _ in 0..256 {
-        match hashes.pop() {
-            Some(val) => ret.push(val),
-            None => break,
+            accounts: Vec::new(),
         }
     }
 
-    ret
-}
+    pub fn append_pending_transaction(&mut self, transaction: Transaction) -> H256 {
+        let value = rlp::encode(&transaction).to_vec();
+        let hash = H256::from(Keccak256::digest(&value).as_slice());
 
-pub fn current_block() -> Block {
-    get_block_by_number(block_height())
-}
+        self.transaction_database.insert(hash, transaction);
+        self.pending_transaction_hashes.push(hash);
+        self.all_pending_transaction_hashes.push(hash);
 
-pub fn stateful() -> MutexGuard<'static, MemoryStateful> {
-    STATEFUL.lock().unwrap()
-}
+        hash
+    }
 
-pub fn accounts() -> Vec<SecretKey> {
-    ACCOUNTS.lock().unwrap().clone()
-}
+    pub fn clear_pending_transactions(&mut self) -> Vec<Transaction> {
+        let transaction_hashes = {
+            let ret_hashes = self.pending_transactions.clone();
+            self.pending_transactions.clear();
+            ret_hashes
+        };
 
-pub fn append_account(key: SecretKey) {
-    ACCOUNTS.lock().unwrap().push(key)
+        let mut transactions = Vec::new();
+        for hash in transaction_hashes {
+            transactions.push(self.transaction_database.get(&hash).unwrap().clone());
+        }
+        transactions
+    }
+
+    pub fn all_pending_transaction_hashes(&self) -> Vec<H256> {
+        self.all_pending_transaction_hashes.clone()
+    }
+
+    pub fn append_block(&mut self, block: Block) -> H256 {
+        let value = rlp::encode(&block).to_vec();
+        let hash = block.header.header_hash();
+        self.block_database.insert(hash, block.clone());
+
+        for transaction in &block.transactions {
+            let transaction_hash = H256::from(Keccak256::digest(&rlp::encode(transaction).to_vec()).as_slice());
+            self.block_transaction_hashes.insert(transaction_hash, hash);
+        }
+
+        assert!(self.block_hashes.len() > 0);
+        let parent_hash = self.block_hashes[block_hashes.len() - 1];
+        let parent = self.total_header_database.get(&parent_hash).unwrap().clone();
+        self.total_header_database.insert(hash, TotalHeader::from_parent(block.header.clone(), &parent));
+
+        self.block_hashes.push(hash);
+        self.current_block = hash;
+
+        hash
+    }
+
+    pub fn insert_receipt(&mut self, transaction_hash: H256, receipt: Receipt) {
+        self.receipt_database.insert(transaction_hash, receipt);
+    }
+
+    pub fn block_height(&self) -> usize {
+        self.block_hashes.len() - 1
+    }
+
+    pub fn get_transaction_block_hash_by_hash(&self, key: H256) -> Result<H256, Error> {
+        self.transaction_block_hashes.get(&key).map(|v| v.clone()).ok_or(Error::NotFound)
+    }
+
+    pub fn get_block_by_hash(&self, key: H256) -> Result<Block, Error> {
+        self.block_database.get(&key).map(|v| v.clone()).ok_or(Error::NotFound)
+    }
+
+    pub fn get_transaction_by_hash(&self, key: H256) -> Result<Transaction, Error> {
+        self.transaction_database.get(&key).map(|v| v.clone()).ok_or(Error::NotFound)
+    }
+
+    pub fn get_receipt_by_transaction_hash(&self, key: H256) -> Result<Receipt, Error> {
+        self.receipt_database.get(&key).map(|v| v.clone()).ok_or(Error::NotFound)
+    }
+
+    pub fn get_block_by_number(&self, index: usize) -> Block {
+        self.get_block_by_hash(self.block_hashes[index]).unwrap()
+    }
+
+    pub fn get_total_header_by_hash(&self, key: H256) -> Result<TotalHeader, Error> {
+        self.total_header_database.get(&key).map(|v| v.clone()).ok_or(Error::NotFound)
+    }
+
+    pub fn get_total_header_by_number(&self, index: usize) -> TotalHeader {
+        self.total_header_database.get(&self.block_hashes[index]).map(|v| v.clone()).unwrap()
+    }
+
+    pub fn get_last_256_block_hashes(&self) -> Vec<H256> {
+        let mut hashes = self.block_hashes.clone();
+        let mut ret = Vec::new();
+
+        for _ in 0..256 {
+            match hashes.pop() {
+                Some(val) => ret.push(val),
+                None => break,
+            }
+        }
+
+        ret
+    }
+
+    pub fn current_block(&self) -> Block {
+        self.get_block_by_number(self.block_height())
+    }
+
+    pub fn stateful_mut(&mut self) -> &mut MemoryStateful {
+        &mut self.stateful
+    }
+
+    pub fn stateful(&self) -> &MemoryStateful {
+        &self.stateful
+    }
+
+    pub fn accounts(&self) -> Vec<SecretKey> {
+        self.accounts.clone()
+    }
+
+    pub fn append_account(&mut self, key: SecretKey) {
+        self.accounts.push(key)
+    }
 }

--- a/src/rpc/filter.rs
+++ b/src/rpc/filter.rs
@@ -4,6 +4,7 @@ use block::{Log, Receipt};
 use sha3::{Digest, Keccak256};
 use std::str::FromStr;
 use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 use blockchain::chain::HeaderHash;
 
 use super::{RPCLog, Either};
@@ -11,7 +12,7 @@ use super::util::*;
 
 use error::Error;
 use rlp;
-use miner;
+use miner::MinerState;
 
 #[derive(Clone, Debug)]
 pub enum TopicFilter {
@@ -53,19 +54,19 @@ fn check_log(log: &Log, index: usize, filter: &TopicFilter) -> bool {
     }
 }
 
-pub fn get_logs(filter: LogFilter) -> Result<Vec<RPCLog>, Error> {
+pub fn get_logs(state: &MinerState, filter: LogFilter) -> Result<Vec<RPCLog>, Error> {
     let mut current_block_number = filter.from_block;
     let mut ret = Vec::new();
 
     while current_block_number >= filter.to_block {
-        if current_block_number > miner::block_height() {
+        if current_block_number > state.block_height() {
             break;
         }
 
-        let block = miner::get_block_by_number(current_block_number);
+        let block = state.get_block_by_number(current_block_number);
         for transaction in &block.transactions {
             let transaction_hash = H256::from(Keccak256::digest(&rlp::encode(transaction).to_vec()).as_slice());
-            let receipt = miner::get_receipt_by_transaction_hash(transaction_hash)?;
+            let receipt = state.get_receipt_by_transaction_hash(transaction_hash)?;
             for i in 0..receipt.logs.len() {
                 let log = &receipt.logs[i];
                 if check_log(log, 0, &filter.topics[0]) &&
@@ -90,7 +91,7 @@ pub fn get_logs(filter: LogFilter) -> Result<Vec<RPCLog>, Error> {
 
 pub struct FilterManager {
     filters: HashMap<usize, Filter>,
-    state: Arc<Mutex<MinerState>,
+    state: Arc<Mutex<MinerState>>,
     unmodified_filters: HashMap<usize, Filter>,
 }
 
@@ -121,6 +122,8 @@ impl FilterManager {
     }
 
     pub fn install_pending_transaction_filter(&mut self) -> usize {
+        let state = self.state.lock().unwrap();
+
         let pending_transactions = state.all_pending_transaction_hashes();
         let id = self.filters.len();
         self.filters.insert(id, Filter::PendingTransaction(pending_transactions.len()));
@@ -134,11 +137,13 @@ impl FilterManager {
     }
 
     pub fn get_logs(&mut self, id: usize) -> Result<Vec<RPCLog>, Error> {
+        let state = self.state.lock().unwrap();
+
         let filter = self.unmodified_filters.get(&id).ok_or(Error::NotFound)?;
 
         match filter {
             &Filter::Log(ref filter) => {
-                let ret = get_logs(filter.clone())?;
+                let ret = get_logs(&state, filter.clone())?;
                 Ok(ret)
             },
             _ => Err(Error::NotFound),
@@ -146,6 +151,7 @@ impl FilterManager {
     }
 
     pub fn get_changes(&mut self, id: usize) -> Result<Either<Vec<String>, Vec<RPCLog>>, Error> {
+        let state = self.state.lock().unwrap();
         let filter = self.filters.get_mut(&id).ok_or(Error::NotFound)?;
 
         match filter {
@@ -168,7 +174,7 @@ impl FilterManager {
                 Ok(Either::Left(ret))
             },
             &mut Filter::Log(ref mut filter) => {
-                let ret = get_logs(filter.clone())?;
+                let ret = get_logs(&state, filter.clone())?;
                 filter.from_block = state.block_height() + 1;
                 Ok(Either::Right(ret))
             },

--- a/src/rpc/filter.rs
+++ b/src/rpc/filter.rs
@@ -95,8 +95,9 @@ pub struct FilterManager {
 }
 
 impl FilterManager {
-    pub fn new() -> Self {
+    pub fn new(state: Arc<Mutex<MinerState>>) -> Self {
         FilterManager {
+            state,
             filters: HashMap::new(),
             unmodified_filters: HashMap::new(),
         }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -7,6 +7,7 @@ use serde::de::DeserializeOwned;
 use serde_json::{self, Value};
 use bigint::{U256, H256, M256, H2048, H64, Address, Gas};
 use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
 use std::sync::mpsc::{channel, Sender, Receiver};
 
 mod serves;
@@ -15,7 +16,7 @@ mod util;
 mod serialize;
 
 use error::Error;
-use super::miner;
+use super::miner::MinerState;
 use self::serialize::*;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -204,8 +204,8 @@ build_rpc_trait! {
     }
 }
 
-pub fn rpc_loop(addr: &SocketAddr, channel: Sender<bool>) {
-    let rpc = serves::MinerEthereumRPC::new(channel);
+pub fn rpc_loop(state: Arc<Mutex<MinerState>>, addr: &SocketAddr, channel: Sender<bool>) {
+    let rpc = serves::MinerEthereumRPC::new(state, channel);
     let mut io = IoHandler::default();
 
     io.extend_with(rpc.to_delegate());

--- a/src/rpc/serves.rs
+++ b/src/rpc/serves.rs
@@ -27,10 +27,11 @@ pub struct MinerEthereumRPC {
 unsafe impl Sync for MinerEthereumRPC { }
 
 impl MinerEthereumRPC {
-    pub fn new(channel: Sender<bool>) -> Self {
+    pub fn new(state: Arc<Mutex<MinerState>>, channel: Sender<bool>) -> Self {
         MinerEthereumRPC {
-            filter: Mutex::new(FilterManager::new()),
+            filter: Mutex::new(state.clone(), FilterManager::new()),
             channel,
+            state,
         }
     }
 }

--- a/src/rpc/util.rs
+++ b/src/rpc/util.rs
@@ -2,7 +2,7 @@ use super::{EthereumRPC, Either, RPCTransaction, RPCBlock, RPCLog, RPCReceipt, R
 use super::filter::*;
 use super::serialize::*;
 use error::Error;
-use miner;
+use miner::MinerState;
 
 use rlp::{self, UntrustedRlp};
 use bigint::{M256, U256, H256, H2048, Address, Gas};
@@ -310,10 +310,10 @@ pub fn from_topic_filter(filter: Option<RPCTopicFilter>) -> Result<TopicFilter, 
     })
 }
 
-pub fn from_log_filter(filter: RPCLogFilter) -> Result<LogFilter, Error> {
+pub fn from_log_filter(state: &MinerState, filter: RPCLogFilter) -> Result<LogFilter, Error> {
     Ok(LogFilter {
-        from_block: from_block_number(filter.from_block)?,
-        to_block: from_block_number(filter.to_block)?,
+        from_block: from_block_number(state, filter.from_block)?,
+        to_block: from_block_number(state, filter.to_block)?,
         address: match filter.address {
             Some(val) => Some(Address::from_str(&val)?),
             None => None,


### PR DESCRIPTION
Move the existing state management from global static to MinerState. This is more "Rusty" and allows multiple instance of RPC in the same process.