### PR TITLE
Incorrect SeqMemory::len usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
  "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sputnikvm 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sputnikvm 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sputnikvm-stateful 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -298,7 +298,7 @@ dependencies = [
  "httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "mime"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicase 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -711,7 +711,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sputnikvm"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -738,7 +738,7 @@ dependencies = [
  "etcommon-trie 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sputnikvm 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sputnikvm 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -980,7 +980,7 @@ dependencies = [
 "checksum magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf0336886480e671965f794bc9b6fce88503563013d1bfb7a502c81fe3ac527"
 "checksum magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40d014c7011ac470ae28e2f76a02bfea4a8480f73e701353b49ad7a8d75f4699"
 "checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
-"checksum mime 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "153f98dde2b135dece079e5478ee400ae1bab13afa52d66590eacfc40e912435"
+"checksum mime 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e3d709ffbb330e1566dc2f2a3c9b58a5ad4a381f740b810cd305dc3f089bc160"
 "checksum mio 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "dbd91d3bfbceb13897065e97b2ef177a09a438cb33612b2d371bf568819a9313"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
 "checksum net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "3a80f842784ef6c9a958b68b7516bc7e35883c614004dd94959a4dca1b716c09"
@@ -1013,7 +1013,7 @@ dependencies = [
 "checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
 "checksum smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c8cbcd6df1e117c2210e13ab5109635ad68a929fcbb8964dc965b76cb5ee013"
 "checksum smallvec 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8fcd03faf178110ab0334d74ca9631d77f94c8c11cc77fcb59538abf0025695d"
-"checksum sputnikvm 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "16e812a760a05d6b9f8d2e4d4437f149d104f7c12a65d93500d09fddbb8da1d9"
+"checksum sputnikvm 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cc0619b2f464117775380dbd858ad6258dcfbb1745889adae10c51fd4ee6b10b"
 "checksum sputnikvm-stateful 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "15e6a56793c925e9533e513cdba7eedf246dc8d8154e218772a8e58b216601f5"
 "checksum stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "15132e0e364248108c5e2c02e3ab539be8d6f5d52a01ca9bbf27ed657316f02b"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"

--- a/src/rpc/serves.rs
+++ b/src/rpc/serves.rs
@@ -611,8 +611,12 @@ impl<P: 'static + Patch + Send> DebugRPC for MinerDebugRPC<P> {
                         };
                         let memory = {
                             let mut ret = Vec::new();
-                            for i in 0..machine.state().memory.len() {
-                                ret.push(Hex(machine.state().memory.read(i.into())));
+                            for i in 0..(if machine.state().memory.len() % 32 == 0 {
+                                machine.state().memory.len() / 32
+                            } else {
+                                machine.state().memory.len() / 32 + 1
+                            }) {
+                                ret.push(Hex(machine.state().memory.read(i.into() * 32)));
                             }
                             ret
                         };

--- a/src/rpc/serves.rs
+++ b/src/rpc/serves.rs
@@ -616,7 +616,8 @@ impl<P: 'static + Patch + Send> DebugRPC for MinerDebugRPC<P> {
                             } else {
                                 machine.state().memory.len() / 32 + 1
                             }) {
-                                ret.push(Hex(machine.state().memory.read(i.into() * 32)));
+                                ret.push(Hex(machine.state().memory.read(U256::from(i) *
+                                                                         U256::from(32))));
                             }
                             ret
                         };


### PR DESCRIPTION
Memory is always u8-indexed and reading should always jump every
32-byte.