### PR TITLE
status and root for getTransactionReceipt

### DIFF
--- a/src/miner/state.rs
+++ b/src/miner/state.rs
@@ -25,6 +25,7 @@ pub struct MinerState {
     block_database: HashMap<H256, Block>,
     receipt_database: HashMap<H256, Receipt>,
     fat_database: Vec<HashMap<Address, HashMap<U256, M256>>>,
+    status_database: HashMap<H256, bool>,
 
     accounts: Vec<SecretKey>,
     database: &'static MemoryDatabase,
@@ -60,6 +61,7 @@ impl MinerState {
             transaction_database: HashMap::new(),
             receipt_database: HashMap::new(),
             fat_database: vec![HashMap::new()],
+            status_database: HashMap::new(),
 
             accounts: Vec::new(),
         }
@@ -248,5 +250,13 @@ impl MinerState {
 
     pub fn append_account(&mut self, key: SecretKey) {
         self.accounts.push(key)
+    }
+
+    pub fn set_receipt_status(&mut self, transaction_hash: H256, is_okay: bool) {
+        self.status_database.insert(transaction_hash, is_okay);
+    }
+
+    pub fn receipt_status(&self, transaction_hash: H256) -> bool {
+        *self.status_database.get(&transaction_hash).unwrap_or(&false)
     }
 }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -67,7 +67,9 @@ pub struct RPCReceipt {
     pub cumulative_gas_used: String,
     pub gas_used: String,
     pub contract_address: Option<String>,
-    pub logs: Vec<RPCLog>
+    pub logs: Vec<RPCLog>,
+    pub root: Hex<H256>,
+    pub status: usize,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/rpc/util.rs
+++ b/src/rpc/util.rs
@@ -7,7 +7,7 @@ use miner::MinerState;
 use rlp::{self, UntrustedRlp};
 use bigint::{M256, U256, H256, H2048, Address, Gas};
 use hexutil::{read_hex, to_hex};
-use block::{Block, TotalHeader, Account, Log, Receipt, FromKey, Transaction, UnsignedTransaction, TransactionAction, GlobalSignaturePatch};
+use block::{Block, TotalHeader, Account, Log, Receipt, FromKey, Transaction, UnsignedTransaction, TransactionAction, GlobalSignaturePatch, RlpHash};
 use blockchain::chain::HeaderHash;
 use sputnikvm::{ValidTransaction, VM, VMStatus, MachineStatus, HeaderParams, SeqTransactionVM, Patch, Memory};
 use sputnikvm_stateful::MemoryStateful;
@@ -117,6 +117,8 @@ pub fn to_rpc_receipt(state: &MinerState, receipt: Receipt, transaction: &Transa
             }
             ret
         },
+        root: Hex(receipt.state_root),
+        status: if state.receipt_status(transaction.rlp_hash()) { 1 } else { 0 },
     })
 }
 


### PR DESCRIPTION
Note that `status` is non-standard in ETC because it stays pre-Byzantium currently.