### PR TITLE
Get svmdev to work with remix and various bug fixes

### DIFF
--- a/src/miner/mod.rs
+++ b/src/miner/mod.rs
@@ -206,6 +206,8 @@ pub fn mine_one<P: Patch>(state: Arc<Mutex<MinerState>>, address: Address) {
                 _ => false,
             }
         );
+
+        println!("0x{:x}", transaction_hash);
     }
 
     let root = state.stateful_mut().root();

--- a/src/rpc/filter.rs
+++ b/src/rpc/filter.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use blockchain::chain::HeaderHash;
+use rpc::RPCLogFilter;
 
 use super::{RPCLog, Either};
 use super::util::*;
@@ -102,6 +103,11 @@ impl FilterManager {
             filters: HashMap::new(),
             unmodified_filters: HashMap::new(),
         }
+    }
+
+    pub fn from_log_filter(&self, log: RPCLogFilter) -> Result<LogFilter, Error> {
+        let state = self.state.lock().unwrap();
+        from_log_filter(&state, log)
     }
 
     pub fn install_log_filter(&mut self, filter: LogFilter) -> usize {

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -121,6 +121,14 @@ pub struct RPCTrace {
     pub struct_logs: Vec<RPCStep>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RPCTraceConfig {
+    pub disable_memory: bool,
+    pub disable_stack: bool,
+    pub disable_storage: bool,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RPCBlockTrace {
@@ -134,11 +142,11 @@ pub struct RPCStep {
     pub error: String,
     pub gas: Hex<Gas>,
     pub gas_cost: Hex<Gas>,
-    pub memory: Vec<Hex<M256>>,
     pub op: u8,
     pub pc: usize,
-    pub stack: Vec<Hex<M256>>,
-    pub storage: HashMap<Hex<U256>, Hex<M256>>,
+    pub memory: Option<Vec<Hex<M256>>>,
+    pub stack: Option<Vec<Hex<M256>>>,
+    pub storage: Option<HashMap<Hex<U256>, Hex<M256>>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -260,15 +268,20 @@ build_rpc_trait! {
         #[rpc(name = "debug_getBlockRlp")]
         fn block_rlp(&self, usize) -> Result<Bytes, Error>;
         #[rpc(name = "debug_traceTransaction")]
-        fn trace_transaction(&self, Hex<H256>) -> Result<RPCTrace, Error>;
+        fn trace_transaction(&self, Hex<H256>, Trailing<RPCTraceConfig>)
+                             -> Result<RPCTrace, Error>;
         #[rpc(name = "debug_traceBlock")]
-        fn trace_block(&self, Bytes) -> Result<RPCBlockTrace, Error>;
+        fn trace_block(&self, Bytes, Trailing<RPCTraceConfig>)
+                       -> Result<RPCBlockTrace, Error>;
         #[rpc(name = "debug_traceBlockByNumber")]
-        fn trace_block_by_number(&self, usize) -> Result<RPCBlockTrace, Error>;
+        fn trace_block_by_number(&self, usize, Trailing<RPCTraceConfig>)
+                                 -> Result<RPCBlockTrace, Error>;
         #[rpc(name = "debug_traceBlockByHash")]
-        fn trace_block_by_hash(&self, Hex<H256>) -> Result<RPCBlockTrace, Error>;
+        fn trace_block_by_hash(&self, Hex<H256>, Trailing<RPCTraceConfig>)
+                               -> Result<RPCBlockTrace, Error>;
         #[rpc(name = "debug_traceBlockFromFile")]
-        fn trace_block_from_file(&self, String) -> Result<RPCBlockTrace, Error>;
+        fn trace_block_from_file(&self, String, Trailing<RPCTraceConfig>)
+                                 -> Result<RPCBlockTrace, Error>;
         #[rpc(name = "debug_dumpBlock")]
         fn dump_block(&self, usize) -> Result<RPCDump, Error>;
     }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -144,7 +144,7 @@ pub struct RPCStep {
     pub gas_cost: Hex<Gas>,
     pub op: u8,
     pub pc: usize,
-    pub memory: Option<Vec<Hex<M256>>>,
+    pub memory: Option<Vec<Bytes>>,
     pub stack: Option<Vec<Hex<M256>>>,
     pub storage: Option<HashMap<Hex<U256>, Hex<M256>>>,
 }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -31,8 +31,8 @@ pub enum Either<T, U> {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
 pub enum RPCTopicFilter {
-    Single(String),
-    Or(Vec<String>)
+    Single(Hex<H256>),
+    Or(Vec<Hex<H256>>)
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -40,7 +40,7 @@ pub enum RPCTopicFilter {
 pub struct RPCLogFilter {
     pub from_block: Option<String>,
     pub to_block: Option<String>,
-    pub address: Option<String>,
+    pub address: Option<Hex<Address>>,
     pub topics: Option<Vec<Option<RPCTopicFilter>>>,
 }
 
@@ -48,25 +48,25 @@ pub struct RPCLogFilter {
 #[serde(rename_all = "camelCase")]
 pub struct RPCLog {
     pub removed: bool,
-    pub log_index: String,
-    pub transaction_index: String,
-    pub transaction_hash: String,
-    pub block_hash: String,
-    pub block_number: String,
-    pub data: String,
-    pub topics: Vec<String>,
+    pub log_index: Hex<usize>,
+    pub transaction_index: Hex<usize>,
+    pub transaction_hash: Hex<H256>,
+    pub block_hash: Hex<H256>,
+    pub block_number: Hex<U256>,
+    pub data: Bytes,
+    pub topics: Vec<Hex<H256>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct RPCReceipt {
-    pub transaction_hash: String,
-    pub transaction_index: String,
-    pub block_hash: String,
-    pub block_number: String,
-    pub cumulative_gas_used: String,
-    pub gas_used: String,
-    pub contract_address: Option<String>,
+    pub transaction_hash: Hex<H256>,
+    pub transaction_index: Hex<usize>,
+    pub block_hash: Hex<H256>,
+    pub block_number: Hex<U256>,
+    pub cumulative_gas_used: Hex<Gas>,
+    pub gas_used: Hex<Gas>,
+    pub contract_address: Option<Hex<Address>>,
     pub logs: Vec<RPCLog>,
     pub root: Hex<H256>,
     pub status: usize,

--- a/src/rpc/serves.rs
+++ b/src/rpc/serves.rs
@@ -580,9 +580,10 @@ impl<P: 'static + Patch + Send> DebugRPC for MinerDebugRPC<P> {
 
         let transaction = state.get_transaction_by_hash(hash.0)?;
         let block = state.get_block_by_hash(state.get_transaction_block_hash_by_hash(hash.0)?)?;
+        let last_block = state.get_block_by_number(if block.header.number == U256::zero() { 0 } else { block.header.number.as_usize() - 1 });
         let last_hashes = state.get_last_256_block_hashes_by_number(block.header.number.as_usize());
 
-        let mut stateful: MemoryStateful<'static> = state.stateful_at(block.header.state_root);
+        let mut stateful: MemoryStateful<'static> = state.stateful_at(last_block.header.state_root);
         for other_transaction in &block.transactions {
             if other_transaction != &transaction {
                 let valid = stateful.to_valid::<P>(transaction.clone())?;
@@ -608,9 +609,10 @@ impl<P: 'static + Patch + Send> DebugRPC for MinerDebugRPC<P> {
         let config = config.unwrap_or(RPCTraceConfig::default());
         let state = self.state.lock().unwrap();
         let block: Block = UntrustedRlp::new(&block_rlp.0).as_val()?;
+        let last_block = state.get_block_by_number(if block.header.number == U256::zero() { 0 } else { block.header.number.as_usize() - 1 });
         let last_hashes = state.get_last_256_block_hashes_by_number(block.header.number.as_usize());
 
-        let mut stateful: MemoryStateful<'static> = state.stateful_at(block.header.state_root);
+        let mut stateful: MemoryStateful<'static> = state.stateful_at(last_block.header.state_root);
         let mut steps = Vec::new();
         for transaction in block.transactions.clone() {
             let (mut local_steps, vm) = replay_transaction::<P>(&stateful, transaction,
@@ -636,9 +638,10 @@ impl<P: 'static + Patch + Send> DebugRPC for MinerDebugRPC<P> {
             return Err(Error::NotFound);
         }
         let block: Block = state.get_block_by_number(number);
+        let last_block = state.get_block_by_number(if block.header.number == U256::zero() { 0 } else { block.header.number.as_usize() - 1 });
         let last_hashes = state.get_last_256_block_hashes_by_number(block.header.number.as_usize());
 
-        let mut stateful: MemoryStateful<'static> = state.stateful_at(block.header.state_root);
+        let mut stateful: MemoryStateful<'static> = state.stateful_at(last_block.header.state_root);
         let mut steps = Vec::new();
         for transaction in block.transactions.clone() {
             let (mut local_steps, vm) = replay_transaction::<P>(&stateful, transaction,
@@ -661,9 +664,10 @@ impl<P: 'static + Patch + Send> DebugRPC for MinerDebugRPC<P> {
         let config = config.unwrap_or(RPCTraceConfig::default());
         let state = self.state.lock().unwrap();
         let block: Block = state.get_block_by_hash(hash.0)?;
+        let last_block = state.get_block_by_number(if block.header.number == U256::zero() { 0 } else { block.header.number.as_usize() - 1 });
         let last_hashes = state.get_last_256_block_hashes_by_number(block.header.number.as_usize());
 
-        let mut stateful: MemoryStateful<'static> = state.stateful_at(block.header.state_root);
+        let mut stateful: MemoryStateful<'static> = state.stateful_at(last_block.header.state_root);
         let mut steps = Vec::new();
         for transaction in block.transactions.clone() {
             let (mut local_steps, vm) = replay_transaction::<P>(&stateful, transaction,
@@ -693,9 +697,10 @@ impl<P: 'static + Patch + Send> DebugRPC for MinerDebugRPC<P> {
 
         let state = self.state.lock().unwrap();
         let block: Block = UntrustedRlp::new(&buffer).as_val()?;
+        let last_block = state.get_block_by_number(if block.header.number == U256::zero() { 0 } else { block.header.number.as_usize() - 1 });
         let last_hashes = state.get_last_256_block_hashes_by_number(block.header.number.as_usize());
 
-        let mut stateful: MemoryStateful<'static> = state.stateful_at(block.header.state_root);
+        let mut stateful: MemoryStateful<'static> = state.stateful_at(last_block.header.state_root);
         let mut steps = Vec::new();
         for transaction in block.transactions.clone() {
             let (mut local_steps, vm) = replay_transaction::<P>(&stateful, transaction,

--- a/src/rpc/util.rs
+++ b/src/rpc/util.rs
@@ -376,15 +376,10 @@ pub fn replay_transaction<P: Patch>(
                         None
                     } else {
                         let mut ret = Vec::new();
-                        for i in 0..(if machine.state().memory.len() % 32 == 0 {
-                            machine.state().memory.len() / 32
-                        } else {
-                            machine.state().memory.len() / 32 + 1
-                        }) {
-                            ret.push(Hex(machine.state().memory.read(U256::from(i) *
-                                                                     U256::from(32))));
+                        for i in 0..machine.state().memory.len() {
+                            ret.push(machine.state().memory.read_raw(U256::from(i)));
                         }
-                        Some(ret)
+                        Some(vec![Bytes(ret)])
                     };
                     let stack = if config.disable_stack {
                         None


### PR DESCRIPTION
You can now test it with the current version of remix (https://github.com/ethereum/remix).

Note that Foundation's remix uses some undocumented APIs, so instead of trying to comply with it, it's better to create a fork that only uses well documented cross-client APIs.