### PR TITLE
Match by code hash instead of address in Solidity breakpoints

### DIFF
--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -138,8 +138,8 @@ pub struct RPCTraceConfig {
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct RPCBreakpointConfig {
-    pub source_map: HashMap<Hex<Address>, String>,
-    pub breakpoints: HashMap<Hex<Address>, String>,
+    pub source_map: HashMap<Hex<H256>, String>,
+    pub breakpoints: HashMap<Hex<H256>, String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -158,9 +158,10 @@ pub struct RPCStep {
     pub op: u8,
     pub pc: usize,
     pub opcode_pc: usize,
+    pub code_hash: Hex<H256>,
+    pub address: Hex<Address>,
     pub breakpoint_index: Option<usize>,
     pub breakpoint: Option<String>,
-    pub breakpoint_address: Option<Hex<Address>>,
     pub memory: Option<Vec<Bytes>>,
     pub stack: Option<Vec<Hex<M256>>>,
     pub storage: Option<HashMap<Hex<U256>, Hex<M256>>>,


### PR DESCRIPTION
Sometimes the breakpoint configurer cannot reliably know the contract
address in advance. However, the code hash is always known. So
matching breakpoints by it is more useful.

In particular, breakpoints config is changed to `code_hash =>
breakpoint string` and source map config is changed to `code_hash =>
source map string`.