### PR TITLE
Support same-file breakpoints in multiple contracts

### DIFF
--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -138,8 +138,15 @@ pub struct RPCTraceConfig {
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct RPCBreakpointConfig {
-    pub source_map: HashMap<Hex<H256>, String>,
-    pub breakpoints: HashMap<Hex<H256>, String>,
+    pub source_map: HashMap<Hex<H256>, RPCSourceMapConfig>,
+    pub breakpoints: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RPCSourceMapConfig {
+    pub source_map: String,
+    pub source_list: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
In particular, the format of breakpoints is changed from
s:l:file_index to s:l:file_name. Passing alongside the source map, it
is now also required to pass the source list from the Solidity
output. Thus allow same-file breakpoints to be matched in multiple
contracts.